### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Gedi/kernel_likelihood.py
+++ b/Gedi/kernel_likelihood.py
@@ -314,7 +314,7 @@ def gradient_sum(kernel,x,y,yerr):
     len_dict=len(kernel.__dict__)
     grad_result=[]    
     for i in np.arange(1,len_dict+1):
-        var = "k%i" %i
+        var = "k{0:d}".format(i)
         k_i = a[var] 
         
         if isinstance(k_i,kl.Sum): #to solve the three sums problem
@@ -403,7 +403,7 @@ def grad_sum_aux(kernel,x,y,yerr,kernelOriginal):
     len_dict=len(kernel.__dict__)
     grad_result=[]    
     for i in np.arange(1,len_dict+1):
-        var = "k%i" %i
+        var = "k{0:d}".format(i)
         k_i = a[var]
         calc=gradient_likelihood_sum(k_i,x,y,yerr,kernelOriginal)
         if isinstance(calc, tuple):        


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jdavidrcamacho:Gedi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jdavidrcamacho:Gedi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)